### PR TITLE
Allow a team member to have no session for a week

### DIFF
--- a/commands/prepare.go
+++ b/commands/prepare.go
@@ -107,6 +107,9 @@ func loadProblem(weekShift int) *libs.Problem {
 	workRanges := ToSlice(GetWeekWorkRanges(beginOfWeek))
 	busyTimes := []*libs.BusyTime{}
 	for _, person := range people {
+		if person.MaxSessionsPerWeek == 0 {
+			continue
+		}
 		personLogger := logger.WithField("person", person.Email)
 		personLogger.Info("Loading busy detail")
 		for _, workRange := range workRanges {

--- a/libs/squads.go
+++ b/libs/squads.go
@@ -51,6 +51,9 @@ func generateSquads(people []*Person, busyTimes []*BusyTime) []*Squad {
 func filterPersons(persons []*Person, wantedIsGoodReviewer bool) []*Person {
 	result := []*Person{}
 	for _, person := range persons {
+		if person.MaxSessionsPerWeek == 0 {
+			continue
+		}
 		if person.IsGoodReviewer == wantedIsGoodReviewer {
 			result = append(result, person)
 		}


### PR DESCRIPTION
By setting the parameter `MaxSessionsPerWeek` to zero, a member is disabled for next planning.